### PR TITLE
Feature/UI improvements

### DIFF
--- a/app/components/attestations/ReviewConfirmationPage.tsx
+++ b/app/components/attestations/ReviewConfirmationPage.tsx
@@ -154,7 +154,7 @@ useEffect(() => {
         </h1>
         <p className="text-center mb-8 text-sm">Thank you for reviewing this project!</p>
         
-        <div className="bg-white rounded-lg shadow-md p-6 mb-12 w-1/5 max-w-md">
+        <div className=" rounded-lg shadow-md p-6 mb-12 w-full max-w-sm">
           <Image 
             src={reviewedProject?.logoUrl || ""}
             alt={reviewedProject?.projectName || "Project"}
@@ -163,7 +163,7 @@ useEffect(() => {
             className="mx-auto rounded-lg"
           />
           <h2 className="text-lg font-semibold text-center mt-4">{reviewedContribution?.projectName || "Project"}</h2>
-          <p className="text-center text-gray-600 mt-2">{reviewedContribution?.desc || "Description"}</p>
+          <p className="text-center  text-gray-600 overflow-hidden mt-2">{reviewedContribution?.desc || "Description"}</p>
         </div>
       </div>
       

--- a/app/components/searchProjects/projectList1.tsx
+++ b/app/components/searchProjects/projectList1.tsx
@@ -135,7 +135,7 @@ export default function ProjectList({
           sortedProjects.slice(0, visibleProjects).map((project) => (
             <div
               key={project.id}
-              className="flex flex-col p-6 border justify-center items-center bg-white text-black border-gray-300 rounded-md w-full h-66 shadow-xl"
+              className="flex flex-col p-6 border cursor-pointer justify-center items-center bg-white text-black border-gray-300 rounded-md w-full h-66 shadow-xl"
               onClick={() => openModal(project)}
             >
               <div className="rounded-md bg-gray-300 w-24 h-24 flex items-center justify-center overflow-hidden mb-4">

--- a/app/components/searchProjects/searchProjects.tsx
+++ b/app/components/searchProjects/searchProjects.tsx
@@ -76,15 +76,23 @@ const SearchProjects = ({ onSearchChange, onFilterChange, onSortOrderChange, cur
   };
 
   const handleSubcategoryChange = (subcategory: string) => {
-    if (selectedSubcategory === subcategory) {
-      setSelectedSubcategory("");
-      onFilterChange(selectedCategory);
-    } else {
-      setSelectedSubcategory(subcategory);
-      onFilterChange(`${selectedCategory}:${subcategory}`);
-    }
-    setIsFilterOpen(false); // Close the filter after subcategory selection
+	const associatedCategory = Object.keys(subcategories).find((category) =>
+	  subcategories[category as higherCategoryKey].includes(subcategory)
+	);
+	if (selectedSubcategory === subcategory) {
+	  setSelectedSubcategory("");
+	  onFilterChange(selectedCategory);  
+	} else {
+	  if (associatedCategory && !selectedCategory) {
+		setSelectedCategory(associatedCategory as higherCategoryKey);
+	  }
+	  setSelectedSubcategory(subcategory);
+	  onFilterChange(`${associatedCategory || selectedCategory}:${subcategory}`);
+	}
+
+	setIsFilterOpen(false); // Close the filter menu after selection
   };
+  
 
   const handleSortOrderChange = (newSortOrder: string) => {
     onSortOrderChange(newSortOrder);
@@ -107,12 +115,12 @@ const SearchProjects = ({ onSearchChange, onFilterChange, onSortOrderChange, cur
               />
               <FaSearch className="absolute left-3 top-1/2 h-[20px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
             </div>
-            <div className="relative w-full sm:w-48" ref={filterRef}>
+            <div className="relative w-full sm:w-56" ref={filterRef}>
               <button
                 onClick={() => setIsFilterOpen(!isFilterOpen)}
                 className="w-full px-4 py-2 text-left bg-white border border-gray-300 rounded-md focus:outline-none flex justify-between items-center truncate"
               >
-                <span>{selectedCategory || selectedSubcategory ? `${selectedCategory}${selectedSubcategory ? `: ${selectedSubcategory}` : ''}` : 'Filter'}</span>
+                <span>{selectedCategory || selectedSubcategory ? `${selectedCategory}${selectedSubcategory ? `` : ''}` : 'Select Category'}</span>
                 <FaChevronDown className={`transition-transform ${isFilterOpen ? 'rotate-180' : ''}`} />
               </button>
               {isFilterOpen && (
@@ -171,7 +179,7 @@ const SearchProjects = ({ onSearchChange, onFilterChange, onSortOrderChange, cur
         </div>
         {(selectedCategory || selectedSubcategory) && (
           <div className="mb-10">
-            <div className="inline-block bg-white text-gray-800 text-sm font-medium py-2 px-4 rounded-md border">
+            <div className="inline-block  text-gray-800 text-sm font-medium py-2 px-4 rounded-md border">
               {`${selectedCategory}${selectedSubcategory ? `: ${selectedSubcategory}` : ''}`}
               <button
                 className="ml-2 text-gray-600 hover:text-gray-800"


### PR DESCRIPTION
- When user is hovering over a project, the default pointer change to a selection pointer.
- If the user opens the filter and directly selects the subcategory they want to see, the category is not shown, neither in the filter nor in the selection that was made. In the selection only ":[subcategory]" is shown. {fixed}
- overflow on text fixed
- Instead of the word "Category", the name of the category now appears. For example, if we select the category "OP Stack" and the subcategory "OP Stack Research and Development", the filter will only show "OP Stack". But the entire category will appear in the selected filter.